### PR TITLE
fix bug with unicode file names

### DIFF
--- a/awesome_avatar/fields.py
+++ b/awesome_avatar/fields.py
@@ -50,7 +50,7 @@ class AvatarField(models.ImageField):
             content = StringIO()
             image.save(content, config.save_format, quality=config.save_quality)
 
-            file_name = '{}.{}'.format(os.path.splitext(file_.name)[0], config.save_format)
+            file_name = u'{}.{}'.format(os.path.splitext(file_.name)[0], config.save_format)
 
             # new_data = SimpleUploadedFile(file.name, content.getvalue(), content_type='image/' + config.save_format)
             new_data = InMemoryUploadedFile(content, None, file_name, 'image/' + config.save_format, len(content.getvalue()), None)


### PR DESCRIPTION
When you are using utf-8 file names you have to use unicode strings as a file names. 
