### PR TITLE
Added compatibility for StringIO when Python 3.x is being used

### DIFF
--- a/awesome_avatar/fields.py
+++ b/awesome_avatar/fields.py
@@ -7,7 +7,10 @@ from awesome_avatar import forms
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import StringIO
 
 try:
     from PIL import Image


### PR DESCRIPTION
I was having problems using Python 3.5.3 with Django 1.11, so I checked the error and it was a subtile incompatibility with Python 3.x. Now it can use the classes it was trying to import, and if it returns an error, it can try to import the Python 3.x class.